### PR TITLE
Add vitest setup and homepage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },
@@ -23,6 +24,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.3",
+    "@testing-library/react": "^14.2.1",
+    "vitest": "^1.5.1",
     "gh-pages": "^6.2.0",
     "typescript": "^5.6.3"
   }

--- a/src/components/__tests__/HomePage.test.tsx
+++ b/src/components/__tests__/HomePage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import HomePage from '../HomePage'
+import { beforeAll, describe, it, expect, vi } from 'vitest'
+
+beforeAll(() => {
+  // Mock IntersectionObserver
+  class MockObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.IntersectionObserver = MockObserver
+
+  // Mock matchMedia
+  // @ts-ignore
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+})
+
+describe('HomePage', () => {
+  it('renders hero heading', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    )
+    expect(screen.getByRole('heading', { name: /shamal musthafa/i })).toBeInTheDocument()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'dist',
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- install vitest and @testing-library/react in package.json
- add test script and vitest config
- add HomePage.test verifying hero heading

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849266e32a0832fb11a4c76908751c7